### PR TITLE
Remove implementation dependency on coherence-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,6 @@ subprojects { Project subproject ->
     apply plugin: "io.micronaut.build.dependency-updates"
 
     apply plugin: "io.micronaut.build.publishing"
-
-    dependencies {
-        implementation(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
-    }
 }
 
 apply plugin: "io.micronaut.build.docs"

--- a/coherence-grpc-client/build.gradle
+++ b/coherence-grpc-client/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     api "io.micronaut:micronaut-runtime"
     api "com.oracle.coherence.ce:coherence-java-client"
 
+    implementation(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
 
     testImplementation "org.mockito:mockito-core:3.7.7"
     testImplementation "org.hamcrest:hamcrest:2.2"

--- a/coherence-grpc-test/build.gradle
+++ b/coherence-grpc-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api "com.oracle.coherence.ce:coherence-grpc-proxy"
     api "com.oracle.coherence.ce:coherence-json"
 
+    implementation(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
 
     testImplementation "org.mockito:mockito-core:3.7.7"
     testImplementation "org.hamcrest:hamcrest:2.2"

--- a/coherence-session/build.gradle
+++ b/coherence-session/build.gradle
@@ -4,6 +4,9 @@ dependencies {
 
     api project(':coherence')
     api "io.micronaut:micronaut-session"
+    api "com.oracle.coherence.ce:coherence"
+
+    implementation(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
 
     testImplementation "io.micronaut:micronaut-http-client"
     testRuntimeOnly "io.micronaut:micronaut-http-server-netty"

--- a/coherence/build.gradle
+++ b/coherence/build.gradle
@@ -5,10 +5,14 @@ dependencies {
     api "io.micronaut:micronaut-inject"
     api "io.micronaut:micronaut-messaging"
     api "io.micronaut:micronaut-runtime"
-    api "com.oracle.coherence.ce:coherence"
 
+    compileOnly(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
+    compileOnly "com.oracle.coherence.ce:coherence"
     compileOnly "com.oracle.coherence.ce:coherence-json"
     compileOnly "com.oracle.coherence.ce:coherence-grpc-proxy"
+
+    testImplementation(platform("com.oracle.coherence.ce:coherence-bom:${coherenceVersion}"))
+    testImplementation "com.oracle.coherence.ce:coherence:${coherenceVersion}"
 
     testImplementation "org.mockito:mockito-core:3.7.7"
     testImplementation "org.hamcrest:hamcrest:2.2"


### PR DESCRIPTION
This PR aims to remove hard dependency on specific Coherence version for `micronaut-coherence` module but to keep it for sub-modules such are `micronaut-coherence-session`, `micronaut-coherence-cache` or `micronaut-distributed-configuration`.