### PR TITLE
Fix catalogue - remove micronaut-micronaut-coherence

### DIFF
--- a/coherence-bom/build.gradle
+++ b/coherence-bom/build.gradle
@@ -2,3 +2,9 @@ plugins {
     id "io.micronaut.build.internal.coherence-base"
     id 'io.micronaut.build.internal.bom'
 }
+micronautBuild {
+    micronautBuild {
+        // required because micronaut-micronaut-coherence was removed
+        tasks.named("checkVersionCatalogCompatibility") { onlyIf { false } }
+    }
+}

--- a/coherence-cache/build.gradle
+++ b/coherence-cache/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.inject.groovy)
 
-    implementation project(":coherence")
+    implementation(project(":micronaut-coherence"))
     api(mn.micronaut.inject)
     api(mnCache.micronaut.cache.core)
     compileOnly(libs.managed.coherence)

--- a/coherence-data/build.gradle
+++ b/coherence-data/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     annotationProcessor(mn.micronaut.inject.java)
 
-    api project(":coherence")
+    api(project(":micronaut-coherence"))
     api(mnData.micronaut.data.model)
     api(mnData.micronaut.data.runtime)
     api(mnData.micronaut.data.processor)
@@ -13,7 +13,7 @@ dependencies {
     compileOnly(libs.managed.coherence)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
-    testAnnotationProcessor project(":coherence-data")
+    testAnnotationProcessor(project(":micronaut-coherence-data"))
 
     testImplementation(platform(libs.boms.coherence))
     testImplementation(libs.managed.coherence)

--- a/coherence-distributed-configuration/build.gradle
+++ b/coherence-distributed-configuration/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    api project(':coherence')
-    implementation project(':coherence-grpc-client')
+    api(project(":micronaut-coherence"))
+    implementation(project(":micronaut-coherence-grpc-client"))
     api(mn.micronaut.inject)
     api(mn.micronaut.runtime)
     implementation(libs.micronaut.discovery.client)

--- a/coherence-grpc-client/build.gradle
+++ b/coherence-grpc-client/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api project(':coherence')
+    api(project(":micronaut-coherence"))
     api(mn.micronaut.inject)
     api(mn.micronaut.runtime)
     api(mnGrpc.micronaut.grpc.runtime)

--- a/coherence-grpc-test/build.gradle
+++ b/coherence-grpc-test/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    api project(':coherence')
-    api project(':coherence-grpc-client')
+    api(project(":micronaut-coherence"))
+    api(project(":micronaut-coherence-grpc-client"))
     api(mn.micronaut.inject)
     api(mn.micronaut.runtime)
     api(libs.managed.coherence.grpc.proxy) {

--- a/coherence-session/build.gradle
+++ b/coherence-session/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api project(':coherence')
+    api(project(":micronaut-coherence"))
     api(mnSession.micronaut.session)
     compileOnly(libs.managed.coherence)
     implementation(mnReactor.micronaut.reactor)

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,10 +28,6 @@ githubBranch=master
 # Micronaut core branch for BOM pull requests
 githubCoreBranch=4.0.x
 
-bomProperty=micronautCoherenceVersion
-# If needed, set additional properties
-bomProperties=coherenceVersion
-
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'coherence-distributed-configuration'
 include 'coherence-data'
 
 micronautBuild {
+    useStandardizedProjectNames=true
     addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-cache")

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,8 @@ plugins {
     id("io.micronaut.build.shared.settings") version "6.3.5"
 }
 
+rootProject.name = 'coherence-parent'
+
 include 'coherence'
 include 'coherence-bom'
 include 'coherence-grpc-client'


### PR DESCRIPTION
without this change:

./gradlew build -x test
grep -inr micronaut-micronaut-coherence *
coherence-bom/build/version-catalog/libs.versions.toml:10:micronaut-micronaut-coherence = "4.0.0-SNAPSHOT"
coherence-bom/build/version-catalog/libs.versions.toml:18:micronaut-coherence-bom = {group = "io.micronaut.coherence", name = "micronaut-coherence-bom", version.ref = "micronaut-micronaut-coherence" }