### PR TITLE
remove @Type from factory methods

### DIFF
--- a/coherence/src/main/java/io/micronaut/coherence/NamedTopicFactories.java
+++ b/coherence/src/main/java/io/micronaut/coherence/NamedTopicFactories.java
@@ -72,16 +72,14 @@ class NamedTopicFactories {
         this.extractorFactory = extractorFactory;
     }
 
-    @Bean(preDestroy = "release")
+    @Bean(preDestroy = "release", typed = NamedTopic.class)
     @Prototype
-    @Type(NamedTopic.class)
     <V> NamedTopic<V> getTopic(InjectionPoint<?> injectionPoint) {
         return getTopicInternal(injectionPoint);
     }
 
     @Bean(preDestroy = "close")
     @Prototype
-    @Type(Publisher.class)
     <V> Publisher<V> getPublisher(InjectionPoint<?> injectionPoint) {
         NamedTopic<V> topic = getTopicInternal(injectionPoint);
         return topic.createPublisher();
@@ -89,7 +87,6 @@ class NamedTopicFactories {
 
     @Bean(preDestroy = "close")
     @Prototype
-    @Type(Subscriber.class)
     @SuppressWarnings({"unchecked", "rawtypes"})
     <V> Subscriber<V> getSubscriber(InjectionPoint<?> injectionPoint) {
         AnnotationMetadata metadata = injectionPoint.getAnnotationMetadata();


### PR DESCRIPTION
Remove `@Type` from factory methods as I don’t think it was doing anything.

`com.tangosol.net.topic. NamedTopic ` looks like:
`public interface NamedTopic<V>  extends NamedCollection`

I assume that given the `@Type` annotation, the intention was that only `NamedTopic` type was injectable not `NamedCollection`.

`com.tangosol.net.topic.Publisher` looks like:

```java
public interface Publisher<V> extends AutoCloseable
```

`com.tangosol.net.topic. Subscriber` looks like:

```java
public interface Subscriber<V> extends AutoCloseable
```